### PR TITLE
add preAppBase getAccount method and rename other preAppbase methods

### DIFF
--- a/Sources/Steem/API.swift
+++ b/Sources/Steem/API.swift
@@ -61,7 +61,7 @@ public struct API {
         public init() {}
     }
     
-    public struct TestnetGetDynamicGlobalProperties: Request {
+    public struct PreAppbaseGetDynamicGlobalProperties: Request {
         public typealias Response = DynamicGlobalProperties
         public let method = "call"
         public let params: CallParams<SignedTransaction>?
@@ -124,7 +124,7 @@ public struct API {
     }
     
     // Note: Uses pre-appbase condenser_api
-    public struct TestnetBroadcastTransaction: Request {
+    public struct PreAppbaseBroadcastTransaction: Request {
         public typealias Response = TransactionConfirmation
         public let method = "call"
         public let params: CallParams<SignedTransaction>?
@@ -212,6 +212,15 @@ public struct API {
     public struct GetAccounts: Request {
         public typealias Response = [ExtendedAccount]
         public let method = "get_accounts"
+        public let params: RequestParams<[String]>?
+        public init(names: [String]) {
+            self.params = RequestParams([names])
+        }
+    }
+    
+    public struct PreAppbaseGetAccounts: Request {
+        public typealias Response = [ExtendedAccount]
+        public let method = "condenser_api.get_accounts"
         public let params: RequestParams<[String]>?
         public init(names: [String]) {
             self.params = RequestParams([names])

--- a/Sources/Steem/API.swift
+++ b/Sources/Steem/API.swift
@@ -57,17 +57,9 @@ public struct API {
 
     public struct GetDynamicGlobalProperties: Request {
         public typealias Response = DynamicGlobalProperties
-        public let method = "get_dynamic_global_properties"
+        public let method = "condenser_api.get_dynamic_global_properties"
+        public let params: RequestParams<[String]>? = RequestParams([])
         public init() {}
-    }
-    
-    public struct PreAppbaseGetDynamicGlobalProperties: Request {
-        public typealias Response = DynamicGlobalProperties
-        public let method = "call"
-        public let params: CallParams<SignedTransaction>?
-        public init() {
-            self.params = CallParams("condenser_api", "get_dynamic_global_properties", [])
-        }
     }
 
     public struct SteemPrices: Decodable {
@@ -115,16 +107,6 @@ public struct API {
     }
 
     public struct BroadcastTransaction: Request {
-        public typealias Response = TransactionConfirmation
-        public let method = "call"
-        public let params: CallParams<SignedTransaction>?
-        public init(transaction: SignedTransaction) {
-            self.params = CallParams("network_broadcast_api", "broadcast_transaction_synchronous", [transaction])
-        }
-    }
-    
-    // Note: Uses pre-appbase condenser_api
-    public struct PreAppbaseBroadcastTransaction: Request {
         public typealias Response = TransactionConfirmation
         public let method = "call"
         public let params: CallParams<SignedTransaction>?
@@ -210,15 +192,6 @@ public struct API {
 
     /// Fetch accounts.
     public struct GetAccounts: Request {
-        public typealias Response = [ExtendedAccount]
-        public let method = "get_accounts"
-        public let params: RequestParams<[String]>?
-        public init(names: [String]) {
-            self.params = RequestParams([names])
-        }
-    }
-    
-    public struct PreAppbaseGetAccounts: Request {
         public typealias Response = [ExtendedAccount]
         public let method = "condenser_api.get_accounts"
         public let params: RequestParams<[String]>?

--- a/Tests/SteemIntegrationTests/API.swift
+++ b/Tests/SteemIntegrationTests/API.swift
@@ -124,7 +124,7 @@ class ClientTest: XCTestCase {
         )
         comment.parentPermlink = "test"
         let vote = Operation.Vote(voter: "test19", author: "test19", permlink: comment.permlink)
-        testnetClient.send(API.TestnetGetDynamicGlobalProperties()) { props, error in
+        testnetClient.send(API.PreAppbaseGetDynamicGlobalProperties()) { props, error in
             XCTAssertNil(error)
             guard let props = props else {
                 return XCTFail("Unable to get props")
@@ -139,7 +139,7 @@ class ClientTest: XCTestCase {
             guard let stx = try? tx.sign(usingKey: key, forChain: testnetId) else {
                 return XCTFail("Unable to sign tx")
             }
-            testnetClient.send(API.TestnetBroadcastTransaction(transaction: stx)) { res, error in
+            testnetClient.send(API.PreAppbaseBroadcastTransaction(transaction: stx)) { res, error in
                 XCTAssertNil(error)
                 if let res = res {
                     XCTAssertFalse(res.expired)
@@ -166,6 +166,16 @@ class ClientTest: XCTestCase {
         XCTAssertEqual(account.id, 180_270)
         XCTAssertEqual(account.name, "almost-digital")
         XCTAssertEqual(account.created, Date(timeIntervalSince1970: 1_496_691_060))
+    }
+    
+    func testTestnetGetAccount() throws {
+        let result = try testnetClient.sendSynchronous(API.PreAppbaseGetAccounts(names: ["almost-digital"]))
+        guard let account = result?.first else {
+            XCTFail("No account returned")
+            return
+        }
+        XCTAssertEqual(account.id, 40413)
+        XCTAssertEqual(account.name, "almost-digital")
     }
 
     func testGetAccountHistory() throws {

--- a/Tests/SteemIntegrationTests/API.swift
+++ b/Tests/SteemIntegrationTests/API.swift
@@ -124,7 +124,7 @@ class ClientTest: XCTestCase {
         )
         comment.parentPermlink = "test"
         let vote = Operation.Vote(voter: "test19", author: "test19", permlink: comment.permlink)
-        testnetClient.send(API.PreAppbaseGetDynamicGlobalProperties()) { props, error in
+        testnetClient.send(API.GetDynamicGlobalProperties()) { props, error in
             XCTAssertNil(error)
             guard let props = props else {
                 return XCTFail("Unable to get props")
@@ -139,7 +139,7 @@ class ClientTest: XCTestCase {
             guard let stx = try? tx.sign(usingKey: key, forChain: testnetId) else {
                 return XCTFail("Unable to sign tx")
             }
-            testnetClient.send(API.PreAppbaseBroadcastTransaction(transaction: stx)) { res, error in
+            testnetClient.send(API.BroadcastTransaction(transaction: stx)) { res, error in
                 XCTAssertNil(error)
                 if let res = res {
                     XCTAssertFalse(res.expired)
@@ -169,7 +169,7 @@ class ClientTest: XCTestCase {
     }
     
     func testTestnetGetAccount() throws {
-        let result = try testnetClient.sendSynchronous(API.PreAppbaseGetAccounts(names: ["almost-digital"]))
+        let result = try testnetClient.sendSynchronous(API.GetAccounts(names: ["almost-digital"]))
         guard let account = result?.first else {
             XCTFail("No account returned")
             return


### PR DESCRIPTION
Adds another pre-appbase call style to GetAccounts from the testnet.