### PR TITLE
expose hexEncoder for testnetIds

### DIFF
--- a/Sources/Steem/ChainId.swift
+++ b/Sources/Steem/ChainId.swift
@@ -11,10 +11,18 @@ public enum ChainId: Equatable {
     case testNet
     /// Custom chain id.
     case custom(Data)
+    public init(string: String) {
+        let data = Data(hexEncoded: string)
+        switch data {
+        case mainNetId: self = .mainNet
+        case testNetId: self = .testNet
+        default: self = .custom(data)
+        }
+    }
 }
 
 fileprivate let mainNetId = Data(hexEncoded: "0000000000000000000000000000000000000000000000000000000000000000")
-fileprivate let testNetId = Data(hexEncoded: "9afbce9f2416520733bacb370315d32b6b2c43d6097576df1c1222859d91eecc")
+fileprivate let testNetId = Data(hexEncoded: "46d82ab7d8db682eb1959aed0ada039a6d49afa1602491f93dde9cac3e8e6c32")
 
 extension ChainId {
     /// The 32-byte chain id.

--- a/Tests/SteemTests/ChainIdTests.swift
+++ b/Tests/SteemTests/ChainIdTests.swift
@@ -1,0 +1,25 @@
+//
+//  ChainIdTests.swift
+//  SteemTests
+//
+//  Created by im on 10/12/18.
+//
+
+import Foundation
+import XCTest
+@testable import Steem
+
+class ChainIdTest: XCTestCase {
+    func testEncodeCustomChainId() {
+        let mockChainId = ChainId(string: "11223344")
+        XCTAssertEqual(mockChainId, ChainId.custom(Data(hexEncoded: "11223344")))
+    }
+    func testTestnetId() {
+        let mockChainId = ChainId.testNet.data
+        XCTAssertEqual(mockChainId, Data(hexEncoded: "46d82ab7d8db682eb1959aed0ada039a6d49afa1602491f93dde9cac3e8e6c32"))
+    }
+    func testMainnetId() {
+        let mockChainId = ChainId.mainNet.data
+        XCTAssertEqual(mockChainId, Data(hexEncoded: "0000000000000000000000000000000000000000000000000000000000000000"))
+    }
+}


### PR DESCRIPTION
update `chainId.testnetId`
expose` chainId.(string: "XXYY")` method to generate properly encoded chain id from arbitrary strings.